### PR TITLE
Fix for latest gmod update.

### DIFF
--- a/lua/autorun/includes/modules/browserpool.lua
+++ b/lua/autorun/includes/modules/browserpool.lua
@@ -99,6 +99,11 @@ local function setupPanel( panel )
 
 	-- Set default URL
 	panel:OpenURL( defaultUrl )
+	
+	-- Fix for "about:blank" being broken
+	if defaultUrl == "about:blank" then
+		panel:SetHTML( "<html></html>" )
+	end
 
 	-- Remove any added function callbacks
 	for obj, tbl in pairs(panel.Callbacks) do

--- a/lua/autorun/includes/modules/browserpool.lua
+++ b/lua/autorun/includes/modules/browserpool.lua
@@ -97,13 +97,13 @@ local function setupPanel( panel )
 	-- Browser panels are usually manually drawn, use a regular panel if not
 	panel:SetPaintedManually(true)
 
-	-- Set default URL
-	panel:OpenURL( defaultUrl )
-	
 	-- Fix for "about:blank" being broken
 	if defaultUrl == "about:blank" then
 		panel:SetHTML( "<html></html>" )
 	end
+
+	-- Set default URL
+	panel:OpenURL( defaultUrl )
 
 	-- Remove any added function callbacks
 	for obj, tbl in pairs(panel.Callbacks) do


### PR DESCRIPTION
about:blank was broken intentionally due to a security vunderability in awesomium I believe.
(But rather than update to something better we just got an even MORE broken API)
I've tested this and it fixes #15 and #16 

I intentionally though this would be better suited to SetURL but apparently that breaks everything, so here it is.
This fix also needs applying to Cinema IIRC.